### PR TITLE
Fix light theme colors and mobile skill card size

### DIFF
--- a/src/components/Blog.tsx
+++ b/src/components/Blog.tsx
@@ -103,7 +103,7 @@ const createBlogItem = (article: typeof allArticles[0], index: number, customOpt
         }
         header={
           <div className="flex items-center justify-between text-xs">
-            <span className="text-white/60">{article.date}</span>
+            <span className="text-[var(--text-secondary)]">{article.date}</span>
             <span className={`font-medium px-2 py-0.5 rounded-md bg-white/10 ${categoryColor.text}`}>
               {article.category}
             </span>
@@ -111,7 +111,7 @@ const createBlogItem = (article: typeof allArticles[0], index: number, customOpt
         }
         footer={
           <div className="flex items-center justify-between">
-            <span className="text-[10px] text-white/50">{article.readTime}</span>
+            <span className="text-[10px] text-[var(--text-secondary)]">{article.readTime}</span>
             <span className="text-accent/80 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
               →
             </span>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -10,7 +10,7 @@ export default function Footer() {
         <div className="grid grid-cols-1 md:grid-cols-12 gap-6">
           <div className="md:col-span-5">
             <h3 className="text-lg font-bold mb-3">Bekircan Akyüz</h3>
-            <p className="text-white/60 mb-4 text-sm leading-relaxed">
+            <p className="text-[var(--text-secondary)] mb-4 text-sm leading-relaxed">
               Software Engineer profesyonel olarak modern web teknolojileri kullanarak
               ölçeklenebilir ve kullanıcı dostu uygulamalar geliştiriyorum.
             </p>
@@ -19,7 +19,7 @@ export default function Footer() {
                 href="https://github.com" 
                 target="_blank" 
                 rel="noopener noreferrer" 
-                className="w-8 h-8 bg-black/20 backdrop-blur-md rounded-md flex items-center justify-center text-white/60 hover:text-white hover:bg-black/30 hover:scale-105 transform transition-all duration-300"
+                className="w-8 h-8 bg-black/20 backdrop-blur-md rounded-md flex items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-black/30 hover:scale-105 transform transition-all duration-300"
                 aria-label="GitHub"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 24 24">
@@ -30,7 +30,7 @@ export default function Footer() {
                 href="https://twitter.com" 
                 target="_blank" 
                 rel="noopener noreferrer" 
-                className="w-8 h-8 bg-black/20 backdrop-blur-md rounded-md flex items-center justify-center text-white/60 hover:text-white hover:bg-black/30 hover:scale-105 transform transition-all duration-300"
+                className="w-8 h-8 bg-black/20 backdrop-blur-md rounded-md flex items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-black/30 hover:scale-105 transform transition-all duration-300"
                 aria-label="Twitter"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 24 24">
@@ -41,7 +41,7 @@ export default function Footer() {
                 href="https://linkedin.com" 
                 target="_blank" 
                 rel="noopener noreferrer" 
-                className="w-8 h-8 bg-black/20 backdrop-blur-md rounded-md flex items-center justify-center text-white/60 hover:text-white hover:bg-black/30 hover:scale-105 transform transition-all duration-300"
+                className="w-8 h-8 bg-black/20 backdrop-blur-md rounded-md flex items-center justify-center text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-black/30 hover:scale-105 transform transition-all duration-300"
                 aria-label="LinkedIn"
               >
                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 24 24">
@@ -52,30 +52,30 @@ export default function Footer() {
           </div>
           
           <div className="md:col-span-2">
-            <h4 className="text-sm font-medium mb-3 text-white/80">Sitemap</h4>
+            <h4 className="text-sm font-medium mb-3 text-[var(--text-primary)] opacity-80">Sitemap</h4>
             <ul className="space-y-1.5 text-sm">
               <li>
-                <Link href="#" className="text-white/60 hover:text-white transition-colors hover:translate-x-1 inline-block transform duration-300">
+                <Link href="#" className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors hover:translate-x-1 inline-block transform duration-300">
                   Ana Sayfa
                 </Link>
               </li>
               <li>
-                <Link href="#skills" className="text-white/60 hover:text-white transition-colors hover:translate-x-1 inline-block transform duration-300">
+                <Link href="#skills" className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors hover:translate-x-1 inline-block transform duration-300">
                   Skills
                 </Link>
               </li>
               <li>
-                <Link href="#work" className="text-white/60 hover:text-white transition-colors hover:translate-x-1 inline-block transform duration-300">
+                <Link href="#work" className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors hover:translate-x-1 inline-block transform duration-300">
                   Çalışmalarım
                 </Link>
               </li>
               <li>
-                <Link href="#blog" className="text-white/60 hover:text-white transition-colors hover:translate-x-1 inline-block transform duration-300">
+                <Link href="#blog" className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors hover:translate-x-1 inline-block transform duration-300">
                   Blog
                 </Link>
               </li>
               <li>
-                <Link href="#contact" className="text-white/60 hover:text-white transition-colors hover:translate-x-1 inline-block transform duration-300">
+                <Link href="#contact" className="text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors hover:translate-x-1 inline-block transform duration-300">
                   İletişim
                 </Link>
               </li>
@@ -83,23 +83,23 @@ export default function Footer() {
           </div>
           
           <div className="md:col-span-5">
-            <h4 className="text-sm font-medium mb-3 text-white/80">İletişim</h4>
+            <h4 className="text-sm font-medium mb-3 text-[var(--text-primary)] opacity-80">İletişim</h4>
             <ul className="space-y-2 text-sm">
-              <li className="flex items-center gap-2 text-white/60 hover:text-white transition-colors group">
+              <li className="flex items-center gap-2 text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors group">
                 <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                 </svg>
-                <a href="mailto:info@example.com" className="hover:text-white transition-all duration-300 group-hover:translate-x-1 inline-block transform">
+                <a href="mailto:info@example.com" className="hover:text-[var(--text-primary)] transition-all duration-300 group-hover:translate-x-1 inline-block transform">
                   info@example.com
                 </a>
               </li>
-              <li className="flex items-center gap-3 text-white/60 hover:text-white transition-colors group">
+              <li className="flex items-center gap-3 text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors group">
                 <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
                 </svg>
                 <span className="group-hover:translate-x-1 transition-transform duration-300">+90 (555) 123 4567</span>
               </li>
-              <li className="flex items-center gap-3 text-white/60 hover:text-white transition-colors group">
+              <li className="flex items-center gap-3 text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors group">
                 <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -112,7 +112,7 @@ export default function Footer() {
       </div>
       <div className="mt-8 pt-4 border-t border-white/5">
         <div className="container mx-auto px-4 max-w-5xl">
-          <p className="text-white/40 text-center text-xs">
+          <p className="text-[var(--text-secondary)] opacity-80 text-center text-xs">
             &copy; {currentYear} Bekircan Akyüz. Tüm hakları saklıdır.
           </p>
         </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -103,7 +103,7 @@ export default function Navbar() {
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
           <div className="flex-shrink-0">
-            <Link href="/" className="text-lg font-medium text-white">
+            <Link href="/" className="text-lg font-medium text-[var(--text-primary)]">
               <Image
                 src="/logo.svg"
                 alt="Logo"
@@ -121,9 +121,9 @@ export default function Navbar() {
                   key={section}
                   href={`#${section}`}
                   onClick={handleNavLinkClick(section)}
-                  className={`px-2 py-2 text-sm font-medium ${activeSection === section 
-                    ? 'text-white border-b-2 border-primary' 
-                    : 'text-gray-300 hover:text-white'} transition-colors duration-200 ease-in-out`}
+                  className={`px-2 py-2 text-sm font-medium ${activeSection === section
+                    ? 'text-[var(--text-primary)] border-b-2 border-primary'
+                    : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'} transition-colors duration-200 ease-in-out`}
                 >
                   {t(`nav.${section}`)}
                 </Link>
@@ -138,7 +138,7 @@ export default function Navbar() {
               <button
                 onClick={toggleLanguage}
                 aria-label={t('aria.toggleLanguage')}
-                className="inline-flex items-center justify-center p-1.5 rounded-md text-gray-300 hover:text-white hover:bg-gray-800 focus:outline-none transition duration-150 ease-in-out"
+                className="inline-flex items-center justify-center p-1.5 rounded-md text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-gray-800 focus:outline-none transition duration-150 ease-in-out"
               >
                 <span className="text-xs font-medium">{language === 'tr' ? 'EN' : 'TR'}</span>
               </button>
@@ -149,7 +149,7 @@ export default function Navbar() {
               <button
                 onClick={toggleTheme}
                 aria-label={t('aria.toggleTheme')}
-                className="inline-flex items-center justify-center p-1.5 rounded-md text-gray-300 hover:text-white hover:bg-gray-800 focus:outline-none transition duration-150 ease-in-out"
+                className="inline-flex items-center justify-center p-1.5 rounded-md text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-gray-800 focus:outline-none transition duration-150 ease-in-out"
               >
                 {theme === 'dark' ? (
                   <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -168,7 +168,7 @@ export default function Navbar() {
               <button
                 onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
                 aria-label={mobileMenuOpen ? t('aria.closeMenu') : t('aria.openMenu')}
-                className="inline-flex items-center justify-center p-2 rounded-md text-gray-300 hover:text-white hover:bg-gray-800 focus:outline-none transition duration-150 ease-in-out"
+                className="inline-flex items-center justify-center p-2 rounded-md text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-gray-800 focus:outline-none transition duration-150 ease-in-out"
               >
                 <svg 
                   className="h-6 w-6" 
@@ -213,9 +213,9 @@ export default function Navbar() {
               key={section}
               href={`#${section}`}
               onClick={handleNavLinkClick(section)}
-              className={`block px-3 py-2 rounded-md text-base font-medium ${activeSection === section 
-                ? 'text-white bg-gray-900' 
-                : 'text-gray-300 hover:text-white hover:bg-gray-800'} transition-colors duration-150 ease-in-out`}
+              className={`block px-3 py-2 rounded-md text-base font-medium ${activeSection === section
+                ? 'text-[var(--text-primary)] bg-gray-900'
+                : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-gray-800'} transition-colors duration-150 ease-in-out`}
             >
               {t(`nav.${section}`)}
             </Link>
@@ -224,14 +224,14 @@ export default function Navbar() {
           <div className="mt-4 pt-4 border-t border-gray-800 flex justify-between">
             <button
               onClick={toggleLanguage}
-              className="inline-flex items-center px-4 py-2 border border-gray-800 rounded-md text-sm font-medium text-gray-300 bg-transparent hover:bg-gray-800 transition-colors duration-150 ease-in-out"
+              className="inline-flex items-center px-4 py-2 border border-gray-800 rounded-md text-sm font-medium text-[var(--text-secondary)] bg-transparent hover:bg-gray-800 hover:text-[var(--text-primary)] transition-colors duration-150 ease-in-out"
             >
               {language === 'tr' ? t('language.en') : t('language.tr')}
             </button>
             
             <button
               onClick={toggleTheme}
-              className="inline-flex items-center px-4 py-2 border border-gray-800 rounded-md text-sm font-medium text-gray-300 bg-transparent hover:bg-gray-800 transition-colors duration-150 ease-in-out"
+              className="inline-flex items-center px-4 py-2 border border-gray-800 rounded-md text-sm font-medium text-[var(--text-secondary)] bg-transparent hover:bg-gray-800 hover:text-[var(--text-primary)] transition-colors duration-150 ease-in-out"
             >
               {theme === 'dark' ? t('theme.light') : t('theme.dark')}
             </button>

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -269,8 +269,8 @@ const SkillCard = ({ skill }: { skill: any }) => {
   };
 
   return (
-    <div 
-      className={`skill-card rounded-xl backdrop-blur-sm transition-all duration-300 shadow-md relative overflow-hidden group min-w-[180px] sm:min-w-[250px] flex flex-col justify-between bg-black/80 border-2 ${classes.border} border-opacity-80`}
+    <div
+      className={`skill-card rounded-xl backdrop-blur-sm transition-all duration-300 shadow-md relative overflow-hidden group min-w-[150px] sm:min-w-[220px] flex flex-col justify-between bg-black/80 border-2 ${classes.border} border-opacity-80`}
     >
       {/* Progress bar - yüzde kadar doldurulan arka plan */}
       <div 
@@ -288,23 +288,23 @@ const SkillCard = ({ skill }: { skill: any }) => {
       <div className="relative z-10 flex-1 px-2 py-1.5 sm:px-4 sm:py-2">
         <div className="flex justify-between items-start mb-1">
           <div>
-            <h3 className="font-semibold text-sm sm:text-base text-white">{skill.name}</h3>
+            <h3 className="font-semibold text-sm sm:text-base text-[var(--text-primary)]">{skill.name}</h3>
             <div className="flex items-center mt-1 mb-0.5">
-              <span 
-                className={`text-[8px] sm:text-[10px] font-medium px-1 py-0.5 sm:px-1.5 rounded ${classes.bg} text-white opacity-90`}
+              <span
+                className={`text-[8px] sm:text-[10px] font-medium px-1 py-0.5 sm:px-1.5 rounded ${classes.bg} text-[var(--text-primary)] opacity-90`}
               >
                 {getCategoryName(skill.category)}
               </span>
             </div>
           </div>
-          <span 
-            className={`text-[10px] sm:text-xs font-medium px-1.5 py-0.5 sm:px-2 rounded-lg ${classes.bg} text-white ${skill.proficiency >= 90 ? 'opacity-90' : 'opacity-75'}`}
+          <span
+            className={`text-[10px] sm:text-xs font-medium px-1.5 py-0.5 sm:px-2 rounded-lg ${classes.bg} text-[var(--text-primary)] ${skill.proficiency >= 90 ? 'opacity-90' : 'opacity-75'}`}
           >
             {skill.proficiency}%
           </span>
         </div>
         
-        <p className="text-[10px] sm:text-xs text-gray-300 opacity-90 mb-1 sm:mb-2 line-clamp-2">
+        <p className="text-[10px] sm:text-xs text-[var(--text-secondary)] opacity-90 mb-1 sm:mb-2 line-clamp-2">
           {skill.description}
         </p>
         
@@ -325,7 +325,7 @@ const SkillCard = ({ skill }: { skill: any }) => {
             </span>
           ))}
           {skill.category && (
-            <span className="inline-block px-2 py-0.5 bg-black/30 text-[10px] rounded-md border border-zinc-700">
+            <span className="inline-block px-2 py-0.5 bg-black/30 text-[10px] rounded-md border border-zinc-700 text-[var(--text-primary)]">
               {skill.category}
             </span>
           )}

--- a/src/components/Work.tsx
+++ b/src/components/Work.tsx
@@ -170,9 +170,9 @@ function FilterButton({ active, onClick, icon, children }: {
     <motion.button
       whileTap={{ scale: 0.97 }}
       onClick={onClick}
-      className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm transition-all duration-300 ${active ? 
-        'bg-accent/20 text-white border-[0.5px] border-accent shadow-sm shadow-accent/20' : 
-        'text-text-secondary bg-white/5 border-[0.5px] border-white/10 hover:border-white/20'}`}
+      className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm transition-all duration-300 ${active ?
+        'bg-accent/20 text-[var(--text-primary)] border-[0.5px] border-accent shadow-sm shadow-accent/20' :
+        'text-[var(--text-secondary)] bg-white/5 border-[0.5px] border-white/10 hover:border-white/20'}`}
     >
       <span className="text-xs">{icon}</span>
       <span>{children}</span>
@@ -187,7 +187,7 @@ function TechBadge({ tech }: { tech: string }) {
       initial={{ opacity: 0, y: 5 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.2 }}
-      className="bg-white/5 backdrop-blur-sm border-[0.5px] border-white/10 px-2 py-0.5 rounded-md text-[10px] font-medium text-white/70 inline-block"
+      className="bg-white/5 backdrop-blur-sm border-[0.5px] border-white/10 px-2 py-0.5 rounded-md text-[10px] font-medium text-[var(--text-secondary)] inline-block"
     >
       {tech}
     </motion.span>
@@ -256,15 +256,15 @@ export default function Work() {
                     <div className="flex-1 min-w-0">
                       <h3 className="text-base font-semibold truncate">{project.title}</h3>
                       <div className="flex items-center gap-2">
-                        <span className="text-xs text-white/70">{project.year}</span>
+                        <span className="text-xs text-[var(--text-secondary)]">{project.year}</span>
                         <span className="h-1 w-1 rounded-full bg-white/20"></span>
-                        <span className="text-xs text-white/70 capitalize">{project.category}</span>
+                        <span className="text-xs text-[var(--text-secondary)] capitalize">{project.category}</span>
                       </div>
                     </div>
                   </div>
                   
                   <div className="p-3 text-sm">
-                    <p className="text-white/70 line-clamp-3 text-xs leading-relaxed">
+                    <p className="text-[var(--text-secondary)] line-clamp-3 text-xs leading-relaxed">
                       {project.description}
                     </p>
                   </div>
@@ -275,7 +275,7 @@ export default function Work() {
                         <TechBadge key={idx} tech={tech} />
                       ))}
                       {project.tech.length > 3 && (
-                        <span className="text-xs text-white/60">+{project.tech.length - 3}</span>
+                        <span className="text-xs text-[var(--text-secondary)]">+{project.tech.length - 3}</span>
                       )}
                     </div>
                     


### PR DESCRIPTION
## Summary
- adjust skill card width for better mobile view
- replace hardcoded white text colors with theme variables
- update navbar, blog, work and footer components for light theme support

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403475ec448324a40bf15e16b053f1